### PR TITLE
removed to need for storing html in a file

### DIFF
--- a/script.js
+++ b/script.js
@@ -3,39 +3,24 @@ const path = require("path");
 const { parse } = require("node-html-parser");
 
 /*
-  Get the HTML for the vocabulary.com list and store it in a file
-  called vocab.html. This file is stored in the directory the script
-  is executed in.
+  Get the HTML for the vocabulary.com list and return it as a string.
 */
 const getHTML = async (vocabUrl) => {
   try {
     const res = await fetch(vocabUrl);
-    const html = await res.text();
 
-    fs.writeFileSync(
-      path.join(__dirname, "vocab.html"),
-      html,
-      "utf-8",
-      (error) => {
-        if (error) throw error;
-        else console.log("Successfully wrote to vocab.html");
-      }
-    );
+    if (!res.ok) throw new Error(`Error: ${res.status} ${res.statusText}`);
+
+    return await res.text();
   } catch (error) {
     throw error;
   }
 };
-
 /*
-  Parse the provided HTML file, then store all the vocabulary words in a text file
+  Parse the provided HTML, then store all the vocabulary words in a text file
   called words.txt. This file is stored in the directory the script is executed in.
 */
-const parseHTML = () => {
-  // Read html
-  const html = fs.readFileSync("./vocab.html", {
-    encoding: "utf-8",
-    flags: "r",
-  });
+const parseHTML = (html) => {
   // Parse html
   const root = parse(html);
   // Select all words
@@ -45,7 +30,9 @@ const parseHTML = () => {
     flags: "w",
   });
   // Write each word to the text file
-  words.forEach((word) => {
+  let line = 15;
+  words.forEach((word, i) => {
+    // Write word
     logger.write(`${word.text}\n`);
   });
   // Close the write stream
@@ -56,11 +43,11 @@ const main = async (args) => {
   try {
     // Get HTML
     console.log("Getting html from vocabulary.com...");
-    await getHTML(args[2]);
+    const html = await getHTML(args[2]);
 
     // Parse HTMl and store it in a text file
     console.log("Parsing html for words...");
-    parseHTML();
+    parseHTML(html);
 
     // Log success message
     console.log("Successfully stored vocab words in words.txt");


### PR DESCRIPTION
Removed fs.writeFileSync after awaiting res.text() from the fetch request. The html file does not need to be saved. Opted to return the html as a string instead.